### PR TITLE
Update Gradle version

### DIFF
--- a/Project 1 - TicTacToe/gradle/wrapper/gradle-wrapper.properties
+++ b/Project 1 - TicTacToe/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4.1-bin.zip


### PR DESCRIPTION
Gradle version in example is old, leading to a `Could not determine java version from ‘9.0.1’` in my application. Updating gradle to 4.4.1 (current stable build) resolves this issue. 